### PR TITLE
Use better error handeling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ rusqlite = { version = "0.20", features = [ "bundled" ] }
 tokio = { version = "0.2", features = [ "full" ] }
 tokio-rustls = "0.14"
 futures-util = "0.3"
+thiserror = "1.0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ tokio = { version = "0.2", features = [ "full" ] }
 tokio-rustls = "0.14"
 futures-util = "0.3"
 thiserror = "1.0.11"
+anyhow = "1.0.26"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use std::env;
 
 use clap;
 use clap::{App, Arg};
+use anyhow::*;
 
 mod server;
 use server::Server;
@@ -46,7 +47,7 @@ impl Config {
 
 static mut CONFIGINNER: ConfigInner = ConfigInner::from_defaults();
 
-fn main() {
+fn main() -> Result<()> {
     let matches = App::new("RPCN")
         .version(clap::crate_version!())
         .author(clap::crate_authors!())
@@ -80,9 +81,7 @@ fn main() {
 
     let mut serv = Server::new(host, port);
 
-    if let Err(e) = serv.start() {
-        println!("Server terminated with error: {}", e);
-    } else {
-        println!("Server terminated normally");
-    }
+    serv.start().context("Server terminated with error")?;
+    println!("Server terminated normally");
+    Ok(())
 }


### PR DESCRIPTION
This pull request creates dedicated error types for both `Server` and `UdpServer` using [`thiserror`](https://crates.io/crates/thiserror)
and  uses the error handling functionalities of [`anyhow`](https://crates.io/crates/anyhow).