### PR TITLE
Fix config.is_sign_tickets()

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,7 @@ impl Config {
 	}
 
 	pub fn is_sign_tickets(&self) -> bool {
-		self.ticket_private_key.is_some()
+		self.sign_tickets
 	}
 
 	pub fn get_verbosity(&self) -> &tracing::Level {


### PR DESCRIPTION
When loading the server config, `config.is_sign_tickets()` would only return true if the `config.ticket_private_key` was loaded in the first place, rather than if SignTickets was specified in the config file. `config.load_ticket_private_key()` will only get called if `config.is_sign_tickets()` returns true, leaving a catch-22 situation where the private key will never get loaded as the private key hasn't been loaded.

(I haven't been able to test this fix unfortunately, as I do not know what a Rust is.)