### PR TITLE
Fix ticket signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "rpcn"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "flatbuffers",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpcn"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["RipleyTom <RipleyTom@users.noreply.github.com>"]
 edition = "2021"
 

--- a/rpcn.cfg
+++ b/rpcn.cfg
@@ -20,6 +20,7 @@ EmailPassword=
 # Determines if tickets are signed
 # If enabled ticket_private.key must contain the private key to sign tickets
 SignTickets=false
+SignTicketsDigest=SHA224
 # Runs a minimal web server to display stats
 StatServer=false
 StatServerHost=0.0.0.0

--- a/servers.cfg
+++ b/servers.cfg
@@ -44,3 +44,12 @@ NPWR01224|1|2|
 #Armored Core V (untested)
 NPWR03050|1|1|
 NPWR03050|1|2|
+#Nascar '15 (untested)
+NPWR09007|1|1|
+NPWR09007|1|2|
+#.hack//Versus (untested)
+NPWR01946|1|1|
+NPWR01946|1|2|
+#Naruto Shippuden: Ultimate Ninja Storm 2
+NPWR00637|1|1|
+NPWR00637|1|2|

--- a/src/server/client/cmd_score.rs
+++ b/src/server/client/cmd_score.rs
@@ -223,7 +223,10 @@ impl Client {
 
 		// Update db
 		let db = Database::new(self.get_database_connection()?);
-		if let Err(_) = db.set_score_data(&com_id, self.client_info.user_id, score_req.pcId(), score_req.boardId(), score_req.score(), score_data_id) {
+		if db
+			.set_score_data(&com_id, self.client_info.user_id, score_req.pcId(), score_req.boardId(), score_req.score(), score_data_id)
+			.is_err()
+		{
 			error!("Unexpected error updating score game data in database!");
 		}
 

--- a/src/server/client/mod.rs
+++ b/src/server/client/mod.rs
@@ -718,8 +718,8 @@ impl Client {
 		let ticket;
 		{
 			let config = self.config.read();
-			let key = config.get_ticket_private_key();
-			ticket = Ticket::new(self.client_info.user_id as u64, &self.client_info.npid, &service_id, cookie, key);
+			let sign_info = config.get_ticket_signing_info();
+			ticket = Ticket::new(self.client_info.user_id as u64, &self.client_info.npid, &service_id, cookie, sign_info);
 		}
 		let ticket_blob = ticket.generate_blob();
 


### PR DESCRIPTION
Note that the signature is now using ASN.1 for ease of use and won't automatically be 56 bytes like before.