### PR TITLE
Add brackets to Message-ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2024-01-05
+
+### Fixed
+
+- Add brackets around Message-ID sent with emails
+
+
 ## [0.9.0] - 2024-01-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "rpcn"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "flatbuffers",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpcn"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["RipleyTom <RipleyTom@users.noreply.github.com>"]
 edition = "2021"
 

--- a/src/server/client/cmd_account.rs
+++ b/src/server/client/cmd_account.rs
@@ -50,7 +50,7 @@ impl Client {
 	}
 
 	fn send_email_template(&self, email_addr: &str, email_username: &str, subject: &str, body: String) -> Result<(), String> {
-		let message_id = format!("{}.{}@rpcs3.net", Client::get_timestamp_nanos(), EMAIL_ID_DISPENSER.fetch_add(1, Ordering::SeqCst));
+		let message_id = format!("<{}.{}@rpcs3.net>", Client::get_timestamp_nanos(), EMAIL_ID_DISPENSER.fetch_add(1, Ordering::SeqCst));
 
 		let email_to_send = Message::builder()
 			.to(Mailbox::new(


### PR DESCRIPTION
### Fixed

- Add brackets around Message-ID sent with emails
